### PR TITLE
Remove Haraka from bosh-on-gcp

### DIFF
--- a/terraform/bosh-resources/modules.tf
+++ b/terraform/bosh-resources/modules.tf
@@ -1,6 +1,0 @@
-module "bosh-haraka" {
-    source      = "github.com/migs/bosh-haraka//terraform"
-    projectid   = "${var.projectid}"
-    prefix      = "${var.prefix}"
-    network     = "${google_compute_network.bosh.name}"
-}


### PR DESCRIPTION
Haraka's network config should not be included by default - it's purpose for testing is now complete.